### PR TITLE
Admin level validation

### DIFF
--- a/project/api/models.py
+++ b/project/api/models.py
@@ -94,6 +94,9 @@ class PoliticalRelation(models.Model):
         if self.start_date > self.end_date:
             raise ValidationError("Start date cannot be later than end date")
 
+        if self.child.admin_level < self.parent.admin_level:
+            raise ValidationError("Child entity's admin level cannot be less than parent entity's")
+
         super(PoliticalRelation, self).clean(*args, **kwargs)
 
     def save(self, *args, **kwargs):  # pylint: disable=W0221

--- a/project/api/models.py
+++ b/project/api/models.py
@@ -95,7 +95,9 @@ class PoliticalRelation(models.Model):
             raise ValidationError("Start date cannot be later than end date")
 
         if self.child.admin_level < self.parent.admin_level:
-            raise ValidationError("Child entity's admin level cannot be less than parent entity's")
+            raise ValidationError(
+                "Child entity's admin level cannot be less than parent entity's"
+            )
 
         super(PoliticalRelation, self).clean(*args, **kwargs)
 

--- a/project/api/tests.py
+++ b/project/api/tests.py
@@ -137,7 +137,7 @@ class ModelTest(TestCase):
 
     def test_model_can_not_create_pr(self):
         """
-        Ensure date checks work
+        Ensure PoliticalRelation validations work
         """
 
         with self.assertRaises(ValidationError):
@@ -147,6 +147,15 @@ class ModelTest(TestCase):
                 parent=self.european_union,
                 child=self.germany,
                 control_type=PoliticalRelation.GROUP,
+            )
+
+        with self.assertRaises(ValidationError):
+            PoliticalRelation.objects.create(
+                start_date="0001-01-01",
+                end_date="0002-01-01",
+                parent=self.germany,
+                child=self.european_union,
+                control_type=PoliticalRelation.DIRECT,
             )
 
     def test_model_can_create_ap(self):


### PR DESCRIPTION
Small PR to ensure parent TEs cannot have a smaller admin_level than their children. Fixes #12. 