### PR TITLE
Auto-generated model documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ venv.bak/
 # env
 django.env
 postgres.env
+
+# docs
+project/graph.svg

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN set -ex \
     musl-dev \
     postgresql-dev \
     linux-headers \
-    pcre-dev 
+    pcre-dev \
+    graphviz
 
 RUN mkdir /config
 COPY /config/requirements.txt /config/

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ run_debug: ## Builds, starts, and runs containers, running the built-in Django w
 exec_debug: ## Runs built-in Django web server
 	docker-compose exec web python manage.py runserver 0.0.0.0:81
 
+# Documentation
+graph: ## Builds a UML class diagram of the models
+	docker-compose exec web python manage.py graph_models -a -g -o graph.svg
+
 # Misc
 test: ## Builds, starts, and runs containers, running the django tests
 	docker-compose run --service-ports web sh init.sh python manage.py test

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -9,3 +9,4 @@ pylint~=2.2.2
 factory-boy~=2.11.1
 django-colorfield~=0.1.15
 django-simple-history~=2.6.0
+docutils~=0.14

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -10,3 +10,4 @@ factory-boy~=2.11.1
 django-colorfield~=0.1.15
 django-simple-history~=2.6.0
 docutils~=0.14
+pydotplus~=2.0.2

--- a/project/chron/settings.py
+++ b/project/chron/settings.py
@@ -39,6 +39,7 @@ ALLOWED_HOSTS = ["*"]
 
 INSTALLED_APPS = [
     "django.contrib.admin",
+    "django.contrib.admindocs",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",

--- a/project/chron/urls.py
+++ b/project/chron/urls.py
@@ -33,6 +33,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
-urlpatterns = [path("admin/", admin.site.urls)]
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("doc/", include("django.contrib.admindocs.urls")),
+]


### PR DESCRIPTION
Fixes #14.

- [x] Admin model documentation available at `/doc/`. Example:
 ![image](https://user-images.githubusercontent.com/6278600/50427133-b2b51e00-0854-11e9-9924-fcf805756301.png)
- [x] UML generator available via `make graph`. Example:
![uml](https://svgshare.com/i/A9K.svg)