### PR TITLE
Remove control types

### DIFF
--- a/project/api/models.py
+++ b/project/api/models.py
@@ -77,11 +77,7 @@ class PoliticalRelation(models.Model):
     DIRECT = 10
     INDIRECT = 20
     GROUP = 30
-    CONTROL_TYPES = (
-        (DIRECT, "direct"),
-        (INDIRECT, "indirect"),
-        (GROUP, "group"),
-    )
+    CONTROL_TYPES = ((DIRECT, "direct"), (INDIRECT, "indirect"), (GROUP, "group"))
     control_type = models.PositiveIntegerField(choices=CONTROL_TYPES)
 
     history = HistoricalRecords()

--- a/project/api/models.py
+++ b/project/api/models.py
@@ -75,17 +75,11 @@ class PoliticalRelation(models.Model):
     end_date = models.DateField()
 
     DIRECT = 10
-    DIRECT_OCCUPIED = 11
-    DIRECT_DISPUTED = 12
     INDIRECT = 20
-    INDIRECT_DISPUTED = 21
     GROUP = 30
     CONTROL_TYPES = (
         (DIRECT, "direct"),
-        (DIRECT_OCCUPIED, "direct_occupied"),
-        (DIRECT_DISPUTED, "direct_disputed"),
         (INDIRECT, "indirect"),
-        (INDIRECT_DISPUTED, "indirect_disputed"),
         (GROUP, "group"),
     )
     control_type = models.PositiveIntegerField(choices=CONTROL_TYPES)


### PR DESCRIPTION
Fixes #38. Removes all control_type_choices with the exception of "direct", "indirect", and "group".