### PR TITLE
Implement caching and GET optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ config/nginx/allowed_ips.conf
 
 # postgres init data
 data/
+
+# silk profiles
+project/profiles/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 script:
   - docker-compose run web black . --exclude /migrations/ --diff --check
   - docker-compose run web pylint ./api/
-  - docker-compose run web ash init.sh python manage.py test
+  - docker-compose run -e ENV=dev web ash init.sh python manage.py test
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 script:
   - docker-compose run web black . --exclude /migrations/ --diff --check
   - docker-compose run web pylint ./api/
-  - docker-compose run -e ENV=dev web ash init.sh python manage.py test
+  - docker-compose run -e ENV=dev web ash init.sh python manage.py test --debug-mode
 
 branches:
   only:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "python.formatting.blackPath": "./.black.py",
   "python.formatting.provider": "black",
-  "python.linting.pylintPath": "./.pylint.py"
+  "python.linting.pylintPath": "./.pylint.py",
+  "python.pythonPath": "/usr/bin/python3"
 }

--- a/config/nginx.dev/django.conf
+++ b/config/nginx.dev/django.conf
@@ -3,13 +3,28 @@ upstream web {
    server web:80;
 }
 
+proxy_cache_path /var/cache/nginx/api levels=1:2 keys_zone=api:15m;
+
+proxy_cache_key $scheme$proxy_host$request_uri;
+log_format cache 'Cached: $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" cs=$upstream_cache_status';
+
 # portal
 server {
   location / {
+    add_header Cache-Control "no-cache, must-revalidate, max-age=0";
+
+    proxy_cache api;
+    proxy_cache_use_stale updating;
+	  proxy_cache_lock on;
+    proxy_ignore_headers X-Accel-Expires Expires Cache-Control;
+    proxy_cache_valid 200 302 10m;
+    proxy_cache_valid 404 1m;
+
     proxy_pass http://web/;
     proxy_read_timeout 300s;
     proxy_connect_timeout 75s;
   }
+
   listen 80;
   server_name localhost;
 

--- a/config/nginx.prod/django.conf
+++ b/config/nginx.prod/django.conf
@@ -3,6 +3,11 @@ upstream web {
    server web:80;
 }
 
+proxy_cache_path /var/cache/nginx/api levels=1:2 keys_zone=api:15m;
+
+proxy_cache_key $scheme$proxy_host$request_uri;
+log_format cache 'Cached: $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" cs=$upstream_cache_status';
+
 # catch requests with an invalid HOST header
 server {
   server_name "";
@@ -16,8 +21,20 @@ server {
   deny all;
 
   location / {
+    add_header Cache-Control "no-cache, must-revalidate, max-age=0";
+
+    proxy_cache api;
+    proxy_cache_use_stale updating;
+	  proxy_cache_lock on;
+    proxy_ignore_headers X-Accel-Expires Expires Cache-Control;
+    proxy_cache_valid 200 302 7s;
+    proxy_cache_valid 404 1m;
+
     proxy_pass http://web/;
+    proxy_read_timeout 300s;
+    proxy_connect_timeout 75s;
   }
+
   listen 80;
   server_name localhost;
 

--- a/config/nginx.prod/django.conf
+++ b/config/nginx.prod/django.conf
@@ -38,8 +38,6 @@ server {
     proxy_cache_valid 404 1d;
 
     proxy_pass http://web/;
-    proxy_read_timeout 300s;
-    proxy_connect_timeout 75s;
   }
 
   listen 80;

--- a/config/nginx.prod/django.conf
+++ b/config/nginx.prod/django.conf
@@ -34,8 +34,8 @@ server {
     proxy_cache_use_stale updating;
 	  proxy_cache_lock on;
     proxy_ignore_headers X-Accel-Expires Expires Cache-Control;
-    proxy_cache_valid 200 302 7s;
-    proxy_cache_valid 404 1m;
+    proxy_cache_valid 200 302 3d;
+    proxy_cache_valid 404 1d;
 
     proxy_pass http://web/;
     proxy_read_timeout 300s;

--- a/config/nginx.prod/django.conf
+++ b/config/nginx.prod/django.conf
@@ -8,19 +8,26 @@ proxy_cache_path /var/cache/nginx/api levels=1:2 keys_zone=api:15m;
 proxy_cache_key $scheme$proxy_host$request_uri;
 log_format cache 'Cached: $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" cs=$upstream_cache_status';
 
-# catch requests with an invalid HOST header
-server {
-  server_name "";
-  listen 80;
-  return 444;
-}
+# Allow real ip from local networks
+# https://nginx.org/en/docs/http/ngx_http_realip_module.html
+set_real_ip_from 192.168.0.0/16;
+set_real_ip_from 10.0.0.0/8;
+set_real_ip_from 172.16.0.0/12;
+set_real_ip_from fc00::/7;
+real_ip_header X-Forwarded-For;
+real_ip_recursive on;
 
 # portal
 server {
-  include allowed_ips.conf;
-  deny all;
-
   location / {
+    # Get allowed IPS for POST requests
+    include allowed_ips.conf;
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#limit_except
+    # Deny everything except GET, HEAD for other ips
+    limit_except GET {
+      deny all;
+    }
+
     add_header Cache-Control "no-cache, must-revalidate, max-age=0";
 
     proxy_cache api;
@@ -36,7 +43,6 @@ server {
   }
 
   listen 80;
-  server_name localhost;
 
   location /static {
     autoindex on;

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -15,3 +15,6 @@ docutils~=0.14
 pydotplus~=2.0.2
 requests~=2.21.0
 django-ordered-model~=3.1.1
+django-redis~=4.10.0
+django-debug-toolbar~=1.11
+django-cacheops~=4.1

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -18,3 +18,4 @@ django-ordered-model~=3.1.1
 django-redis~=4.10.0
 django-debug-toolbar~=1.11
 django-cacheops~=4.1
+django-silk~=3.0.1

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -12,3 +12,5 @@ services:
       - ./config/nginx.dev:/etc/nginx/conf.d
   web:
     container_name: django01
+    environment:
+      - ENV=dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,8 @@ services:
       - django.env
       - postgres.env
     restart: always
+  redis:
+    restart: always
+    image: redis:alpine
+    expose:
+      - '6379'

--- a/project/api/tests.py
+++ b/project/api/tests.py
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from datetime import date
 from django.core.exceptions import ValidationError
 from django.contrib.gis.geos import Point, Polygon, MultiPoint
 from django.db import transaction
@@ -680,7 +681,7 @@ class APITest(APITestCase):
         Ensure we can query for all AtomicPolygons
         """
 
-        url = reverse("atomicpolygon-list")
+        url = reverse("atomicpolygon-list-fast")
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data[0]["id"], self.alsace_geom.pk)
@@ -700,7 +701,7 @@ class APITest(APITestCase):
         Ensure we can create SpacetimeVolumes
         """
 
-        url = reverse("spacetimevolume-list")
+        url = "/api/spacetime-volumes/"  # reverse("spacetimevolume-list")
         data = {
             "start_date": "0001-01-01",
             "end_date": "0002-01-01",
@@ -737,10 +738,10 @@ class APITest(APITestCase):
         Ensure we can query for all SpacetimeVolumes
         """
 
-        url = reverse("spacetimevolume-list")
+        url = reverse("spacetimevolume-list-fast")
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data[0]["end_date"], "0002-01-01")
+        self.assertEqual(response.data[0]["end_date"], date(2, 1, 1))
 
     def test_api_can_query_stv(self):
         """

--- a/project/api/urls.py
+++ b/project/api/urls.py
@@ -34,7 +34,6 @@ ROUTER.register(r"map-settings", views.MapSettingsViewSet)
 ROUTER.register(r"narrations", views.NarrationViewSet)
 
 urlpatterns = [
-    path("", include(ROUTER.urls)),
     path(
         "mvt/cached-data/<int:zoom>/<int:x_cor>/<int:y_cor>",
         views.mvt_cacheddata,
@@ -50,4 +49,7 @@ urlpatterns = [
         views.mvt_narration_events,
         name="mvt-narrationevents",
     ),
+    path("spacetime-volumes/", views.get_stvs, name="spacetimevolume-list"),
+    path("atomic-polygons/", views.get_stvs, name="atomicpolygon-list"),
+    path("", include(ROUTER.urls)),
 ]

--- a/project/api/urls.py
+++ b/project/api/urls.py
@@ -49,7 +49,7 @@ urlpatterns = [
         views.mvt_narration_events,
         name="mvt-narrationevents",
     ),
-    path("spacetime-volumes/", views.get_stvs, name="spacetimevolume-list"),
-    path("atomic-polygons/", views.get_stvs, name="atomicpolygon-list"),
+    path("spacetime-volumes/all/", views.get_stvs, name="spacetimevolume-list-fast"),
+    path("atomic-polygons/all/", views.get_stvs, name="atomicpolygon-list-fast"),
     path("", include(ROUTER.urls)),
 ]

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -18,8 +18,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 from django.db import connection
-from django.http import Http404, HttpResponse
-from rest_framework import viewsets, mixins
+from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.urls import reverse
+from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from silk.profiling.profiler import silk_profile
@@ -105,6 +106,12 @@ class AtomicPolygonViewSet(viewsets.ModelViewSet):
     queryset = AtomicPolygon.objects.all()
     serializer_class = AtomicPolygonSerializer
 
+    def list(self, request):  # pylint: disable=W0221
+        """
+        Redirect to the function view for increased performance
+        """
+        return HttpResponseRedirect(reverse("spacetimevolume-list-fast"))
+
 
 @api_view(["GET"])
 @silk_profile(name="AtomicPolyNoSer")
@@ -117,13 +124,7 @@ def get_aps(request):
     return Response(data)
 
 
-class SpacetimeVolumeViewSet(
-    mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
-    mixins.UpdateModelMixin,
-    mixins.DestroyModelMixin,
-    viewsets.GenericViewSet,
-):
+class SpacetimeVolumeViewSet(viewsets.ModelViewSet):
     """
     ViewSet for SpacetimeVolumes
     """
@@ -135,6 +136,12 @@ class SpacetimeVolumeViewSet(
         .defer("visual_center")
     )
     serializer_class = SpacetimeVolumeSerializer
+
+    def list(self, request):  # pylint: disable=W0221
+        """
+        Redirect to the function view for increased performance
+        """
+        return HttpResponseRedirect(reverse("spacetimevolume-list-fast"))
 
 
 @api_view(["GET"])

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from django.db import connection
 from django.http import Http404, HttpResponse
 from rest_framework import viewsets
+from silk.profiling.profiler import silk_profile
 
 from .models import (
     TerritorialEntity,
@@ -108,8 +109,17 @@ class SpacetimeVolumeViewSet(viewsets.ModelViewSet):
     ViewSet for SpacetimeVolumes
     """
 
-    queryset = SpacetimeVolume.objects.all()
+    queryset = (
+        SpacetimeVolume.objects.all()
+        .select_related("entity")
+        .prefetch_related("related_events", "territory")
+    )
     serializer_class = SpacetimeVolumeSerializer
+
+    @silk_profile(name="SpacetimeVolumeViewSet")
+    def list(self, request, *args, **kwargs):
+        print("*")
+        return super(SpacetimeVolumeViewSet, self).list(request, *args, **kwargs)
 
 
 class NarrativeViewSet(viewsets.ModelViewSet):

--- a/project/chron/settings.py
+++ b/project/chron/settings.py
@@ -64,19 +64,20 @@ else:
 
 
 MIDDLEWARE = [
-    #    "django.middleware.security.SecurityMiddleware",
-    #    "django.contrib.sessions.middleware.SessionMiddleware",
+    # "django.middleware.security.SecurityMiddleware",
+    # "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
-    #    "django.middleware.csrf.CsrfViewMiddleware",
-    #    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    #    "django.contrib.auth.middleware.RemoteUserMiddleware",
-    #    "django.contrib.messages.middleware.MessageMiddleware",
-    #    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    # "django.middleware.csrf.CsrfViewMiddleware",
+    # "django.contrib.auth.middleware.AuthenticationMiddleware",
+    # "django.contrib.auth.middleware.RemoteUserMiddleware",
+    # "django.contrib.messages.middleware.MessageMiddleware",
+    # "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
 if DEBUG:
     MIDDLEWARE.extend(
         [
+            "django.contrib.sessions.middleware.SessionMiddleware",
             "debug_toolbar.middleware.DebugToolbarMiddleware",
             "silk.middleware.SilkyMiddleware",
         ]
@@ -167,7 +168,7 @@ SESSION_CACHE_ALIAS = "default"
 
 CACHEOPS_REDIS = "redis://redis:6379/0"
 CACHEOPS_DEFAULTS = {"timeout": 60 * 15}
-CACHEOPS = {"*.*": {"ops": "all"}}
+CACHEOPS = {"api.*": {"ops": "all"}}
 
 
 # Rest Framework

--- a/project/chron/settings.py
+++ b/project/chron/settings.py
@@ -64,14 +64,14 @@ else:
 
 
 MIDDLEWARE = [
-    "django.middleware.security.SecurityMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
+    #    "django.middleware.security.SecurityMiddleware",
+    #    "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.auth.middleware.RemoteUserMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    #    "django.middleware.csrf.CsrfViewMiddleware",
+    #    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    #    "django.contrib.auth.middleware.RemoteUserMiddleware",
+    #    "django.contrib.messages.middleware.MessageMiddleware",
+    #    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
 if DEBUG:

--- a/project/chron/settings.py
+++ b/project/chron/settings.py
@@ -167,7 +167,7 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
 
 CACHEOPS_REDIS = "redis://redis:6379/0"
-CACHEOPS_DEFAULTS = {"timeout": 60 * 15}
+CACHEOPS_DEFAULTS = {"timeout": 60 * 60 * 24}
 CACHEOPS = {"api.*": {"ops": "all"}}
 
 

--- a/project/chron/settings.py
+++ b/project/chron/settings.py
@@ -34,6 +34,8 @@ DEBUG = os.environ.get("ENV", "dev") == "dev"
 
 ALLOWED_HOSTS = ["web", "127.0.0.1", "localhost"]
 
+INTERNAL_IPS = ["172.20.0.1", "127.0.0.1"]
+
 
 # Application definition
 
@@ -52,6 +54,8 @@ INSTALLED_APPS = [
     "rest_framework",
     "rest_framework_gis",
     "ordered_model",
+    "debug_toolbar",
+    "cacheops",
 ]
 
 MIDDLEWARE = [
@@ -63,6 +67,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.RemoteUserMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
 
 ROOT_URLCONF = "chron.urls"
@@ -133,6 +138,24 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
+
+# Caching
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://redis:6379/0",
+        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+    }
+}
+
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+SESSION_CACHE_ALIAS = "default"
+
+CACHEOPS_REDIS = "redis://redis:6379/0"
+CACHEOPS_DEFAULTS = {"timeout": 60 * 15}
+CACHEOPS = {"*.*": {"ops": "all"}}
+
 
 # Rest Framework
 

--- a/project/chron/settings.py
+++ b/project/chron/settings.py
@@ -54,9 +54,14 @@ INSTALLED_APPS = [
     "rest_framework",
     "rest_framework_gis",
     "ordered_model",
-    "debug_toolbar",
-    "cacheops",
+    "silk",
 ]
+
+if DEBUG:
+    INSTALLED_APPS.append("debug_toolbar")
+else:
+    INSTALLED_APPS.append("cacheops")
+
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -67,8 +72,16 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.RemoteUserMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
+
+if DEBUG:
+    MIDDLEWARE.extend(
+        [
+            "debug_toolbar.middleware.DebugToolbarMiddleware",
+            "silk.middleware.SilkyMiddleware",
+        ]
+    )
+
 
 ROOT_URLCONF = "chron.urls"
 
@@ -170,3 +183,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.AllowAny"],
     "DEFAULT_RENDERER_CLASSES": DEFAULT_RENDERER_CLASSES,
 }
+
+SILKY_PYTHON_PROFILER = True
+SILKY_PYTHON_PROFILER_BINARY = True
+SILKY_PYTHON_PROFILER_RESULT_PATH = "profiles/"

--- a/project/chron/urls.py
+++ b/project/chron/urls.py
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include
 
@@ -25,3 +26,8 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("doc/", include("django.contrib.admindocs.urls")),
 ]
+
+if settings.DEBUG:
+    import debug_toolbar
+
+    urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns

--- a/project/chron/urls.py
+++ b/project/chron/urls.py
@@ -30,4 +30,7 @@ urlpatterns = [
 if settings.DEBUG:
     import debug_toolbar
 
-    urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns
+    urlpatterns = [
+        path("__debug__/", include(debug_toolbar.urls)),
+        path("silk/", include("silk.urls")),
+    ] + urlpatterns

--- a/project/chron/urls.py
+++ b/project/chron/urls.py
@@ -27,7 +27,8 @@ urlpatterns = [
     path("doc/", include("django.contrib.admindocs.urls")),
 ]
 
-if settings.DEBUG and 'silk' in settings.INSTALLED_APPS:
+print(settings.DEBUG)
+if settings.DEBUG and "silk" in settings.INSTALLED_APPS:
     import debug_toolbar
 
     urlpatterns = [

--- a/project/chron/urls.py
+++ b/project/chron/urls.py
@@ -27,10 +27,10 @@ urlpatterns = [
     path("doc/", include("django.contrib.admindocs.urls")),
 ]
 
-if settings.DEBUG:
+if settings.DEBUG and 'silk' in settings.INSTALLED_APPS:
     import debug_toolbar
 
     urlpatterns = [
         path("__debug__/", include(debug_toolbar.urls)),
-        path("silk/", include("silk.urls")),
+        path("silk/", include("silk.urls", namespace="silk")),
     ] + urlpatterns

--- a/project/chron/urls.py
+++ b/project/chron/urls.py
@@ -27,7 +27,6 @@ urlpatterns = [
     path("doc/", include("django.contrib.admindocs.urls")),
 ]
 
-print(settings.DEBUG)
 if settings.DEBUG and "silk" in settings.INSTALLED_APPS:
     import debug_toolbar
 


### PR DESCRIPTION
- [x] GET requests optimized for `/spacetime-volumes/` and `/atomic-polygons/` (initial request 4.5x faster!)
    * Important: GET for all STVs moved to `/spacetime-volumes/all/`. I realize this isn't the most RESTful way of doing things but `POST /spacetime-volumes/` was failing due to the overwritten ViewSet method. `GET /spacetime-volumes/` now returns a redirect. 
- [x] Add redis caching for 24 hours
- [x] Add nginx caching for 3 days
- [x] Profiling and debug-toolbar available when `settings.Debug` is true