### PR TITLE
Features for courses

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 project/*.json
+project/*.json.xz
 data

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ project/graph.svg
 
 # dbdumps
 project/*.json
+project/*.json.xz
 
 # postgres init data
 data/

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ loaddata: ## Restore data from previous dump
 	fi; \
 	if [ -f "project/$${NAME}.json" ]; then \
 		echo Loading $${NAME}.json; \
-		docker-compose exec web python manage.py loaddata $${NAME}; \
+		docker-compose exec web python manage.py loaddata $${NAME}.json; \
 	else \
 		echo Error: No file to load; \
 	fi;

--- a/project/api/serializers.py
+++ b/project/api/serializers.py
@@ -221,7 +221,9 @@ class NarrativeSerializer(ModelSerializer):
         Retrieves year of first narration in set
         """
         if obj.narration_set.first() is not None:
-            return jd2gcal(obj.narration_set.order_by('map_datetime').first().map_datetime, 0)[0]
+            return jd2gcal(
+                obj.narration_set.order_by("map_datetime").first().map_datetime, 0
+            )[0]
         return None
 
     def get_end_year(self, obj):  # pylint: disable=R0201
@@ -229,7 +231,9 @@ class NarrativeSerializer(ModelSerializer):
         Retrieves year of last narration in set
         """
         if obj.narration_set.last() is not None:
-            return jd2gcal(obj.narration_set.order_by('map_datetime').last().map_datetime, 0)[0]
+            return jd2gcal(
+                obj.narration_set.order_by("map_datetime").last().map_datetime, 0
+            )[0]
         return None
 
     def get_votes(self, obj):  # pylint: disable=R0201

--- a/project/api/serializers.py
+++ b/project/api/serializers.py
@@ -220,18 +220,16 @@ class NarrativeSerializer(ModelSerializer):
         """
         Retrieves year of first narration in set
         """
-
         if obj.narration_set.first() is not None:
-            return jd2gcal(obj.narration_set.first().map_datetime, 0)[0]
+            return jd2gcal(obj.narration_set.order_by('map_datetime').first().map_datetime, 0)[0]
         return None
 
     def get_end_year(self, obj):  # pylint: disable=R0201
         """
         Retrieves year of last narration in set
         """
-
         if obj.narration_set.last() is not None:
-            return jd2gcal(obj.narration_set.last().map_datetime, 0)[0]
+            return jd2gcal(obj.narration_set.order_by('map_datetime').last().map_datetime, 0)[0]
         return None
 
     def get_votes(self, obj):  # pylint: disable=R0201

--- a/project/api/urls.py
+++ b/project/api/urls.py
@@ -48,15 +48,10 @@ urlpatterns = [
         name="mvt-cities",
     ),
     path(
-        "mvt/narratives/<int:narrative>/<int:zoom>/<int:x_cor>/<int:y_cor>",
-        views.mvt_narration_events,
-        name="mvt-narrationevents",
+        "mvt/narratives/<int:zoom>/<int:x_cor>/<int:y_cor>",
+        views.mvt_narratives,
+        name="mvt-narratives",
     ),
     path("mvt/stv/<int:zoom>/<int:x_cor>/<int:y_cor>", views.mvt_stv, name="mvt-stv"),
-    path(
-        "mvt/visual-center/<int:zoom>/<int:x_cor>/<int:y_cor>",
-        views.mvt_visual_center,
-        name="mvt-visualcenter",
-    ),
     path("", include(ROUTER.urls)),
 ]


### PR DESCRIPTION
Reduced number of endpoints for MVT tiles - less requests from user, more options to cache data
- New layer for Military Symbols
- Narration pins and symbols are served from `/api/mvt/narratives/{z}/{x}/{y}`
Narrative ID is no longer required
- Cities and visual center can be accessed via `/api/mvt/cities/{z}/{x}/{y}`

Use ordered list to retrieve start_date and end_date for narratives fix #119 

Dump and load commands for database 